### PR TITLE
MoreWaita: Use more generic `/usr/local/share/icons/` location instead of Fedora Atomic one

### DIFF
--- a/MoreWaita.sh
+++ b/MoreWaita.sh
@@ -11,7 +11,7 @@ check_dir() {
 
 # Detect MoreWaita and Adwaita-colors locations
 possible_paths=(
-    "/var/usrlocal/share/icons"
+    "/usr/local/share/icons"
     "/usr/share/icons"
     "$HOME/.local/share/icons"
 )


### PR DESCRIPTION
 `/usr/local/share/` is a symlink to `/var/usrlocal/share/` in Fedora Atomic.
However, this is specific to Fedora Atomic only, so use the original `/usr/local/share/` location to be more compatible.